### PR TITLE
Added code to check for partial text string in elements

### DIFF
--- a/tests/pa11y/README.md
+++ b/tests/pa11y/README.md
@@ -1,4 +1,0 @@
-# VisualReview-protractor example project
-
-docker build -t visualreview .
-docker run -d visualreview

--- a/tests/pa11y/docker/README.md
+++ b/tests/pa11y/docker/README.md
@@ -9,4 +9,8 @@ Make sure you [have Docker installed][docker]. Clone or download this repository
 
 From there, run `docker-compose -f compose/docker-compose.yml up` to begin building the Docker containers. 
 
-Once you see terminal output from `web_1` and `database_1`, Pa11y Dashboard should be ready to go. Navigate to [http://localhost:8000][localhost] in your browser, and you should see the Pa11y Dashboard welcome screen.
+Once you see terminal output from `web_1` and `database_1`, Pa11y Dashboard should be ready to go. 
+
+Navigate to [http://localhost:8000][localhost] in your browser, and you should see the Pa11y Dashboard welcome screen.
+
+Click the "+" to add new url

--- a/tests/src/features/TASK138-Pagination.feature
+++ b/tests/src/features/TASK138-Pagination.feature
@@ -6,15 +6,15 @@ Feature: As a PAR user
     Background:
         Given I open the url "/styleguide/pagination"
         And the title is "PAR Styleguide Pagination | Regulatory Authority"
-        Then I expect that element "li.pager__item.pagerer-prefix span" contains the text "Showing 1-10 of 462 results"
+        Then I expect that element "li.pager__item.pagerer-prefix span" contains the text "Showing 1-10"
 
     Scenario Outline: pagination check
         Given I click on the link "<page link>"
         Then I expect that element "li.pager__item.pagerer-prefix span" contains the text "<page set>"
 
         Examples:
-            | page link | page set                     |
-            | 2         | Showing 11-20 of 462 results |
-            | 3         | Showing 21-30 of 462 results |
-            | 4         | Showing 31-40 of 462 results |
-            | 5         | Showing 41-50 of 462 results |
+            | page link | page set      |
+            | 2         | Showing 11-20 |
+            | 3         | Showing 21-30 |
+            | 4         | Showing 31-40 |
+            | 5         | Showing 41-50 |

--- a/tests/src/support/check/checkContainsText.js
+++ b/tests/src/support/check/checkContainsText.js
@@ -47,9 +47,9 @@ module.exports = (type, element, falseCase, expectedText, done) => {
     }
 
     if (boolFalseCase) {
-        expect(text).to.not.equal(stringExpectedText);
+        expect(text).to.not.contain(stringExpectedText);
     } else {
-        expect(text).to.equal(stringExpectedText);
+        expect(text).to.contain(stringExpectedText);
     }
 
     doneCallback();


### PR DESCRIPTION
The fixes the current failing tests on master branch (now the pagination test does a partial check, instead of relying on total number of pages remaining the same)