### PR TITLE
copy assets into /assets/vendor/images/

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ gulp.task('cp-assets', [], function() {
   gulp.src([
     "node_modules/govuk_frontend_toolkit/images/**"
   ])
-  .pipe(gulp.dest(themeDir + '/assets/vendor'));
+  .pipe(gulp.dest(themeDir + '/assets/vendor/images'));
 });
 
 gulp.task('watch', function() {


### PR DESCRIPTION
this will copy the necessary images in this folder to make the GDS footer show the crown and OGL emblem.