### PR TITLE
Use the govuk_template "HTML version" assets in a custom `images/PAR`…

### DIFF
--- a/web/themes/custom/par_theme/sass/_footer.scss
+++ b/web/themes/custom/par_theme/sass/_footer.scss
@@ -106,9 +106,9 @@
             height: 17px;
             overflow:hidden;
             text-indent: -999em;
-            background: file-url("images/open-government-licence.png") 0 0 no-repeat;
+            background: url("../assets/images/PAR/open-government-licence.png") 0 0 no-repeat;
             @include device-pixel-ratio() {
-              background-image: file-url("images/open-government-licence_2x.png");
+              background-image: url("../assets/images/PAR/open-government-licence_2x.png");
               background-size: 41px 17px;
             }
           }
@@ -146,7 +146,7 @@
       a {
         display: block;
 
-        background-image: file-url("images/govuk-crest.png");
+        background-image: url("../assets/images/PAR/govuk-crest.png");
         background-repeat: no-repeat;
         background-position: 50% 0%;
 
@@ -155,12 +155,12 @@
         }
 
         @include device-pixel-ratio() {
-          background-image: file-url("images/govuk-crest-2x.png");
+          background-image: url("../assets/images/PAR/govuk-crest-2x.png");
           background-size: 125px 102px;
         }
 
         @include ie(6) {
-          background-image: file-url("images/govuk-crest-ie.png");
+          background-image: url("../assets/images/PAR/govuk-crest-ie.png");
         }
 
         text-align: center;


### PR DESCRIPTION
… folder because the ejs/mustache versions on npm registry do not contain these assets so they cannot be copied/inherited in the assets folder using a Gulp copy mechanism.