### PR TITLE
form password fields should also have the form-control attribute.

### DIFF
--- a/web/themes/custom/par_theme/templates/input--password.html.twig
+++ b/web/themes/custom/par_theme/templates/input--password.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Theme override for an 'input' #type form element.
+ *
+ * Available variables:
+ * - attributes: A list of HTML attributes for the input element.
+ * - children: Optional additional rendered elements.
+ *
+ * @see template_preprocess_input()
+ */
+#}
+
+<span class="form-hint">{{ attributes.placeholder }}</span>
+<input{{ attributes.addClass('form-control').removeAttribute('placeholder') }} />{{ children }}


### PR DESCRIPTION
<img width="1039" alt="log_in___regulatory_authority" src="https://user-images.githubusercontent.com/150512/28219735-e3b26c10-68b4-11e7-8006-3142ed9be40b.png">

improve the login form by simply applying a CSS class