### PR TITLE
remove whitespace & drush sql-drop before sql-cli /sync

### DIFF
--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -4,14 +4,14 @@
 
     cd /vagrant/docker
     sudo sh destroy-dependencies.sh
-    
+
 # Install dependencies
 
     docker exec -i par_beta_web bash -c 'su - composer -c "cd ../../var/www/html && php composer.phar install"'
     docker exec -i par_beta_web bash -c "cd /var/www/html/tests && rm -rf node_modules/* && ../../../../usr/local/n/versions/node/7.2.1/bin/npm install"
     docker exec -i par_beta_web bash -c "rm -rf node_modules/* && ../../../usr/local/n/versions/node/7.2.1/bin/npm install"
     docker exec -i par_beta_web bash -c "../../../usr/local/n/versions/node/7.2.1/bin/npm run gulp"
-    
+
 # Setup the development settings file:
 
 if [ ! -f ../web/sites/settings.local.php ]; then
@@ -22,6 +22,7 @@ fi
 # Load the test data:
 
     sleep 5 # Time for the server to boot
+    docker exec -i par_beta_web bash -c "vendor/bin/drush @dev --root=/var/www/html/web sql-drop"
     docker exec -i par_beta_web bash -c "vendor/bin/drush sql-cli @dev --root=/var/www/html/web < docker/fresh_drupal_postgres.sql"
 
 # Update Drupal


### PR DESCRIPTION
I often run into problems with xmlsitemap and watchdog PDOexceptions saying table already exists in database without having a clean postgres database.

![image](https://user-images.githubusercontent.com/150512/28531050-87633c56-708d-11e7-89bb-975b7b58c6b7.png)
