### PR TITLE
as per all input--xx.html.twig templates, email needs the wrapper

### DIFF
--- a/web/themes/custom/par_theme/templates/input--email.html.twig
+++ b/web/themes/custom/par_theme/templates/input--email.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Theme override for an 'input' #type form element.
+ *
+ * Available variables:
+ * - attributes: A list of HTML attributes for the input element.
+ * - children: Optional additional rendered elements.
+ *
+ * @see template_preprocess_input()
+ */
+#}
+
+<span class="form-hint">{{ attributes.placeholder }}</span>
+<input{{ attributes.addClass('form-control').removeAttribute('placeholder') }} />{{ children }}


### PR DESCRIPTION
email input fields need the form-control class.