### PR TITLE
Update View to say 'List of Partnerships' and update the tests

### DIFF
--- a/sync/views.view.par_data_transition_journey_1_step_1.yml
+++ b/sync/views.view.par_data_transition_journey_1_step_1.yml
@@ -504,7 +504,7 @@ display:
           entity_field: partnership_status
           plugin_id: string
       sorts: {  }
-      title: 'List of Partnerships for a Primary Authority'
+      title: 'List of Partnerships'
       header: {  }
       footer: {  }
       empty: {  }

--- a/tests/src/features/current-sprint/PAR179-Capture-Partnership-Entity-Section-States.feature
+++ b/tests/src/features/current-sprint/PAR179-Capture-Partnership-Entity-Section-States.feature
@@ -10,5 +10,5 @@ Feature: Capture the state of a section in an entity; ie., whether or not an ent
 
     Scenario: Capture the state of a section in an entity
         Given I open the url "/dv/partnership-dashboard"
-        Then the element "h1" contains the text "List of Partnerships for a Primary Authority"
+        Then the element "h1" contains the text "List of Partnerships"
         Then I expect that element "#view-partnership-status-table-column" is visible

--- a/tests/src/features/user-journey-change-partnership-detail.feature
+++ b/tests/src/features/user-journey-change-partnership-detail.feature
@@ -82,5 +82,5 @@ Feature: User Journey 1 (happy path)
         And I click on the button "#edit-next"
         Then the element "#block-par-theme-content" contains the text "confirmed_authority"
         When I click on the link "Go back to your partnerships"
-        Then the element "h1" contains the text "List of Partnerships for a Primary Authority"
+        Then the element "h1" contains the text "List of Partnerships"
         And I click on the link "Log out"

--- a/tests/src/features/user-journey-documentation.feature
+++ b/tests/src/features/user-journey-documentation.feature
@@ -34,5 +34,5 @@ Feature: User Journey 1 (happy path)
         When I click on the button "#edit-next"
     # Then the element ".placeholder" not contains the text "Error"
     # When I click on the link "Go back to your partnerships"
-    # Then the element "h1" contains the text "List of Partnerships for a Primary Authority"
+    # Then the element "h1" contains the text "List of Partnerships"
     # And I click on the link "Log out"

--- a/tests/src/features/user-journey-inspection-plans.feature
+++ b/tests/src/features/user-journey-inspection-plans.feature
@@ -31,5 +31,5 @@ Feature: User Journey 1 (happy path)
         And I click on the checkbox ".form-checkbox"
         And I click on the button "#edit-next"
         When I click on the link "Go back to your partnerships"
-        Then the element "h1" contains the text "List of Partnerships for a Primary Authority"
+        Then the element "h1" contains the text "List of Partnerships"
         And I click on the link "Log out"

--- a/tests/src/features/user-journey-send-invite.feature
+++ b/tests/src/features/user-journey-send-invite.feature
@@ -37,5 +37,5 @@ Feature: User Journey 1 (happy path)
     # Then the element "#edit-email-subject" contains the text "Test change subject line"
     # Then the element "#edit-email-body" contains the text "Test change meassage body [invite:invite-accept-link]"
     # When I click on the link "Go back to your partnerships"
-    # Then the element "h1" contains the text "List of Partnerships for a Primary Authority"
+    # Then the element "h1" contains the text "List of Partnerships"
     # And I click on the link "Log out"


### PR DESCRIPTION
Because we use this view across Business and PA, the title should not say List of Partnerships for a Primary Authority…