### PR TITLE
Replace par logo

### DIFF
--- a/web/themes/custom/par_theme/sass/par.scss
+++ b/web/themes/custom/par_theme/sass/par.scss
@@ -264,3 +264,8 @@ a.no-pointer-events {
   background: url(/themes/custom/par_theme/assets/images/document-icon.png) 0px 2px/15px 20px no-repeat;
   padding-left: 20px;
 }
+
+/* Removes bottom border underline from header logo. We are not using a logo in Transition */
+#global-header #logo {
+  border-bottom: none;
+}

--- a/web/themes/custom/par_theme/templates/page.html.twig
+++ b/web/themes/custom/par_theme/templates/page.html.twig
@@ -62,9 +62,9 @@
   <div class="header-wrapper">
     <div class="header-global">
       <div class="header-logo">
-        <a href="/" title="Go to the Primary Authority Register homepage" id="logo" class="content">
-          <img src="/{{ directory }}/assets/images/PAR/pa-logo-large.jpg" width="80" height="80" alt="Primary Authority Register logo">
-        </a>
+        <h1 id="logo" class="content">
+          Primary Authority
+        </h1>      
       </div>
     </div>
     <div class="header-proposition">
@@ -74,13 +74,9 @@
           <a href="/" id="proposition-name">
             {% if gdsHeadingTitle %}
               {{ gdsHeadingTitle }}
-            {% else %}
-              PAR
-            {% endif %} Pages
+            {% endif %}
             </a>
-          <ul id="proposition-links">
-            <li><a href="/">Home Page</a></li>
-          </ul>
+          <ul id="proposition-links"></ul>
         </nav>
 
         {{page.header}}


### PR DESCRIPTION
Replaces the 'green box' PAR logo with a textual heading as requested by RD. SCSS updated accordingly.