### PR TITLE
Fixes organisation name heading display

### DIFF
--- a/web/modules/custom/par_flow_transition_partnership_details/src/Controller/ParFlowTransitionTaskListController.php
+++ b/web/modules/custom/par_flow_transition_partnership_details/src/Controller/ParFlowTransitionTaskListController.php
@@ -32,7 +32,7 @@ class ParFlowTransitionTaskListController extends ParBaseController {
     // Organisation Name & Address.
     $build['organisation']['label'] = [
       '#type' => 'markup',
-      '#prefix' => '<h2>',
+      '#prefix' => '<h2 class="heading-medium">',
       '#suffix' => '</h2>',
       '#markup' => $organisation_name
     ];


### PR DESCRIPTION
Adds .heading-medium class to the h2 tag surrounding the organisation name as required by UX.

![image](https://user-images.githubusercontent.com/6898065/29378207-2487cb48-82b6-11e7-8ca9-bdd7affe6cc6.png)
