### PR TITLE
Fixes pagination display problem where the pagination moves

### DIFF
--- a/web/themes/custom/par_theme/sass/par.scss
+++ b/web/themes/custom/par_theme/sass/par.scss
@@ -269,3 +269,10 @@ a.no-pointer-events {
 #global-header #logo {
   border-bottom: none;
 }
+
+/* Pagerer overrides */
+
+div.pagerer-container {
+  display: inline-block;
+  margin-top: 2em;
+}


### PR DESCRIPTION
Not a final solution, but sets pagerer container to display as inline-block, so it's always under the table.