### PR TITLE
Uses organisation_name instead of name to display organisation name

### DIFF
--- a/web/modules/custom/par_flow_transition_partnership_details/src/Controller/ParFlowTransitionTaskListController.php
+++ b/web/modules/custom/par_flow_transition_partnership_details/src/Controller/ParFlowTransitionTaskListController.php
@@ -26,7 +26,7 @@ class ParFlowTransitionTaskListController extends ParBaseController {
 
     if ($par_data_organisation) {
 
-      $organisation_name = $par_data_organisation ? $par_data_organisation->retrieveStringValue('name') : '';
+      $organisation_name = $par_data_organisation ? $par_data_organisation->retrieveStringValue('organisation_name') : '';
 
       // Organisation Name & Address.
       $build['organisation']['label'] = [


### PR DESCRIPTION
Somehow this got undone - redone now.