### PR TITLE
Partnership details copy changes 21/07

### DIFF
--- a/web/modules/custom/par_flow_transition_partnership_details/par_flow_transition_partnership_details.routing.yml
+++ b/web/modules/custom/par_flow_transition_partnership_details/par_flow_transition_partnership_details.routing.yml
@@ -27,7 +27,7 @@ par_flow_transition_partnership_details.overview:
   path: '/dv/primary-authority-partnerships/{par_data_partnership}/details'
   defaults:
     _form: '\Drupal\par_flow_transition_partnership_details\Form\ParFlowTransitionOverviewForm'
-    _title: 'Viewing/confirming partnership details'
+    _title: 'Updating the Primary Authority Register'
   requirements:
     _permission: 'access par journey transition partnership details'
     par_data_partnership: \d+
@@ -39,7 +39,7 @@ par_flow_transition_partnership_details.about:
   path: '/dv/primary-authority-partnerships/{par_data_partnership}/details/about'
   defaults:
     _form: '\Drupal\par_flow_transition_partnership_details\Form\ParFlowTransitionAboutForm'
-    _title: 'Edit the information about the Partnership'
+    _title: 'Updating the Primary Authority Register'
   requirements:
     _permission: 'access par journey transition partnership details'
     par_data_partnership: \d+

--- a/web/modules/custom/par_flow_transition_partnership_details/src/Form/ParFlowTransitionOverviewForm.php
+++ b/web/modules/custom/par_flow_transition_partnership_details/src/Form/ParFlowTransitionOverviewForm.php
@@ -243,17 +243,17 @@ class ParFlowTransitionOverviewForm extends ParBaseForm {
       '#items' => $regulatory_function_list_items
     ];
 
-    // Partnership Confirmation.
+    // "Partnership Arrangements have been agreed" confirmation.
     $form['partnership_agreement'] = [
       '#type' => 'checkbox',
-      '#title' => t('A written summary of partnership agreement, such as Memorandum of Understanding, has been agreed with the Business.'),
+      '#title' => t('A written summary of the partnership arrangements has been agreed with the business.'),
       '#disabled' => $this->getDefaultValues('partnership_agreement'),
       '#checked' => $this->getDefaultValues('partnership_agreement'),
       '#default_value' => $this->getDefaultValues('partnership_agreement'),
       '#return_value' => 'on',
     ];
 
-    // Partnership Confirmation.
+    // "Partnership Information is correct" confirmation.
     $form['confirmation'] = [
       '#type' => 'checkbox',
       '#title' => t('I confirm that the partnership information above is correct.'),


### PR DESCRIPTION
Copy correction - viewing/confirming partnership details
URL: /dv/primary-authority-partnerships/4/details
Page title should read, 'Updating the Primary Authority Register'
Checkbox options should read:
I confirm that the partnership information above is correct
A written summary of the partnership arrangements has been agreed with the business