### PR TITLE
Deployment script prompting for most variables

### DIFF
--- a/cf/push.sh
+++ b/cf/push.sh
@@ -178,13 +178,3 @@ cf set-env par-beta-$ENV PAR_GOVUK_NOTIFY_TEMPLATE $PAR_GOVUK_NOTIFY_TEMPLATE
 cf restage par-beta-$ENV
 
 cf ssh par-beta-$ENV -c "cd app/tools && python post_deploy.py"
-
-####################################################################################
-# Go back to the /cf directory to set the domain, if any
-####################################################################################
-
-cd ..
-
-if [ -f update-domain-$ENV.sh ]; then
-    sh update-domain-$ENV.sh
-fi

--- a/cf/push.sh
+++ b/cf/push.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-ENV=$1
-VER=$2
-
 ####################################################################################
 # Run this script from the /cf directory of the repository
-# Usage:
-#    ./push.sh <env> <version>
-#
-# e.g.
-#    ./push.sh demo v0.0.33
+# Users will be prompted for:
+#       Target environent
+#       Build version
+#       Vault unseal key
 ####################################################################################
 # You'll need the following installed
 #
@@ -70,12 +66,25 @@ command -v cf >/dev/null 2>&1 || {
     exit 1 
 }
 
+echo -n "Enter the environment name (e.g. staging): "
+read ENV
+echo -n "Enter the build version (e.g. v1.0.0): "
+read VER
+
 ####################################################################################
 # Unseal the vault - will prompt for GitHub personal access token
+# Vault is first sealed to ensure that deployment can't happen unless user has
+# the unseal token. Mostly this is to avoid copy/paste unintended deployments. 
 ####################################################################################
 
-echo "Unsealing the vault.."
+vault seal
+echo -n "Enter the vault unseal token: "
 vault unseal
+
+if [ $? == 1 ]; then
+    echo "Unable to unseal vault"
+    exit 1;
+fi
 
 ####################################################################################
 # Get AWS access keys to download the versioned package from S3
@@ -101,8 +110,8 @@ PAR_GOVUK_NOTIFY_TEMPLATE=`vault read -field=PAR_GOVUK_NOTIFY_TEMPLATE secret/pa
 # Reseal the vault
 ####################################################################################
 
-#echo "Resealing the vault.."
-#vault seal
+echo "Resealing the vault.."
+vault seal
 
 ####################################################################################
 # Pull the packaged version from S3

--- a/cf/update-domain-production.sh
+++ b/cf/update-domain-production.sh
@@ -1,2 +1,0 @@
-cf update-service beis-par-cdn-route -c '{"domain": "primary-authority.beis.gov.uk"}'
-


### PR DESCRIPTION
Force user to enter vault unseal key even if vault is already unsealed. Prompt for environment name and build version rather than pass them as command line arguments.