### PR TITLE
Trying to rectify issues with chromedriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,8 +112,9 @@ before_script:
 
 script:
   - travis_retry docker exec -i par_beta_web /var/www/html/vendor/phpunit/phpunit/phpunit
+  - travis_retry docker exec -ti par_beta_web bash -c "cd tests && rm -rf node_modules && npm install"
   - travis_retry docker exec -ti par_beta_web bash -c "cd tests && /usr/local/n/versions/node/7.2.1/bin/npm run test:build"
-  
+
 #-----------------------------------------------------------------------------
 # Generate HTML reports with screenshots. HTML report location: tests/reports/allure-reports/index.html, TAR it up.
 #-----------------------------------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ before_script:
 
 script:
   - travis_retry docker exec -i par_beta_web /var/www/html/vendor/phpunit/phpunit/phpunit
-  - travis_retry docker exec -ti par_beta_web bash -c "cd tests && rm -rf node_modules && npm install"
+  - travis_retry docker exec -ti par_beta_web bash -c "cd tests && rm -rf node_modules && /usr/local/n/versions/node/7.2.1/bin/npm install"
   - travis_retry docker exec -ti par_beta_web bash -c "cd tests && /usr/local/n/versions/node/7.2.1/bin/npm run test:build"
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR reinstates the `rm -rf node_modules`, having figured out that this directory is actually cached. we should use `npm update` in the future to invalidate this directory cache.