### PR TITLE
Drush "no extra" fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,9 @@
             "drush/drush": {
                 "Drush sql-dump compatibility with PostgresSQL 9.5+": "./patches/drush-sqldump-postgres95.patch"
             },
+            "drush/drush": {
+                "Fix SQL dump problem where extra params are passed when trying only to list tables": "./patches/drush-sql-dump-no-extra-fix.patch"
+            },            
             "drupal/clamav": {
                 "Add support for ClamAV via a REST daemon": "./patches/clamav_add_rest_client.patch"
             },

--- a/patches/drush-sql-dump-no-extra-fix.patch
+++ b/patches/drush-sql-dump-no-extra-fix.patch
@@ -1,0 +1,40 @@
+diff --git a/lib/Drush/Sql/SqlBase.php b/lib/Drush/Sql/SqlBase.php
+index 0d8871ce..04132062 100644
+--- a/lib/Drush/Sql/SqlBase.php
++++ b/lib/Drush/Sql/SqlBase.php
+@@ -142,7 +142,7 @@ class SqlBase {
+    * @return
+    *   TRUE on success, FALSE on failure
+    */
+-  public function query($query, $input_file = NULL, $result_file = '') {
++  public function query($query, $input_file = NULL, $result_file = '', $includeExtra = true) {
+     $input_file_original = $input_file;
+     if ($input_file && drush_file_is_tarball($input_file)) {
+       if (drush_shell_exec('gzip -d %s', $input_file)) {
+@@ -164,7 +164,7 @@ class SqlBase {
+       $this->command(),
+       $this->creds(),
+       $this->silent(), // This removes column header and various helpful things in mysql.
+-      drush_get_option('extra', $this->query_extra),
++      $includeExtra ? drush_get_option('extra', $this->query_extra) : '',
+       $this->query_file,
+       drush_escapeshellarg($input_file),
+     );
+diff --git a/lib/Drush/Sql/Sqlpgsql.php b/lib/Drush/Sql/Sqlpgsql.php
+index e8945c73..fd748b1c 100644
+--- a/lib/Drush/Sql/Sqlpgsql.php
++++ b/lib/Drush/Sql/Sqlpgsql.php
+@@ -96,9 +96,12 @@ class Sqlpgsql extends SqlBase {
+   }
+ 
+   public function listTables() {
+-    $return = $this->query(PSQL_SHOW_TABLES);
++    $return = $this->query(PSQL_SHOW_TABLES, NULL, '', false);
+     $tables = drush_shell_exec_output();
+     if (!empty($tables)) {
++      foreach ($tables as &$table) {
++        $table = trim($table);
++      }
+       return $tables;
+     }
+     return array();


### PR DESCRIPTION
The problem was that when Drush was using the Postgres tools to get a list of tables, it was also passing in all the "extra" params from the drush aliases - thinking it was a good idea because it was all part of the "sql-dump" command. This caused the table list exec to fail and caused the remained of the logic to go wonky as well. This patch fixes it by explicitly telling one of the functions not to add the extra stuff, when asked not to do so, such as when it is being called for a table list.