### PR TITLE
Cancel all flow forms and cancel flow form submit handlers.

### DIFF
--- a/web/modules/custom/par_flows/src/Form/ParBaseForm.php
+++ b/web/modules/custom/par_flows/src/Form/ParBaseForm.php
@@ -372,6 +372,54 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
   }
 
   /**
+   * Cancel submit handler to clear all the current flow temporary form data.
+   *
+   * @code
+   * $form['actions']['cancel'] = [
+   *   '#type' => 'submit',
+   *   '#name' => 'cancel',
+   *   '#value' => $this->t('Cancel'),
+   *   '#submit' => ['::cancelForm'],
+   * ];
+   * @endcode
+   *
+   * @param array $form
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   */
+  public function cancelForm(array &$form, FormStateInterface $form_state) {
+    // Delete form storage.
+    $this->deleteStore();
+
+    // Go to cancel step.
+    $next = $this->getFlow()->getNextRoute('cancel');
+    $form_state->setRedirect($next, $this->getRouteParams());
+  }
+
+  /**
+   * Cancel submit handler to clear the current temporary form data.
+   *
+   * @code
+   * $form['actions']['previous'] = [
+   *   '#type' => 'submit',
+   *   '#name' => 'previous',
+   *   '#value' => $this->t('Previous'),
+   *   '#submit' => ['::cancelThisForm'],
+   * ];
+   * @endcode
+   *
+   * @param array $form
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   */
+  public function cancelThisForm(array &$form, FormStateInterface $form_state) {
+    // Delete specific form storage.
+    $this->deleteFormTempData($this->getFormId());
+
+    // Go to cancel step.
+    $next = $this->getFlow()->getNextRoute('cancel');
+    $form_state->setRedirect($next, $this->getRouteParams());
+  }
+
+  /**
    * Find form element anchor/HTML id.
    *
    * @param string $name


### PR DESCRIPTION
An option for previous/back and flow cancel.

example usage
`
$form['actions']['cancel'] = [
      '#type' => 'submit',
      '#name' => 'cancel',
      '#value' => $this->t('Cancel'),
      '#submit' => ['::cancelForm'],
      '#limit_validation_errors' => [],
      '#attributes' => [
        'class' => ['btn-link']
      ],
    ];
`