### PR TITLE
PAR-817 Re-cache the related entities when saving an entity

### DIFF
--- a/web/modules/custom/par_data/src/ParDataManager.php
+++ b/web/modules/custom/par_data/src/ParDataManager.php
@@ -458,6 +458,11 @@ class ParDataManager implements ParDataManagerInterface {
    *   An array of entities found with this value.
    */
   public function getEntitiesByProperty($type, $field, $value) {
+    // Check that a value is specified.
+    if (is_null($value)) {
+      return [];
+    }
+
     return $this->entityTypeManager
       ->getStorage($type)
       ->loadByProperties([$field => $value]);

--- a/web/modules/custom/par_data/src/ParDataStorage.php
+++ b/web/modules/custom/par_data/src/ParDataStorage.php
@@ -2,10 +2,9 @@
 
 namespace Drupal\par_data;
 
-use Drupal\Core\Cache\Cache;
-use Drupal\Core\Config\Entity\ConfigEntityStorage;
 use Drupal\par_data\Entity\ParDataEntity;
 use Drupal\trance\TranceStorage;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Defines the storage class for flows.
@@ -14,6 +13,14 @@ use Drupal\trance\TranceStorage;
  * entity loading mechanisms.
  */
 class ParDataStorage extends TranceStorage {
+
+  protected $par_data_manager;
+
+  public function __construct(\Drupal\Core\Entity\EntityTypeInterface $entity_type, \Drupal\Core\Database\Connection $database, \Drupal\Core\Entity\EntityManagerInterface $entity_manager, \Drupal\Core\Cache\CacheBackendInterface $cache, \Drupal\Core\Language\LanguageManagerInterface $language_manager) {
+    parent::__construct($entity_type, $database, $entity_manager, $cache, $language_manager);
+
+    $this->par_data_manager = \Drupal::service('par_data.manager');
+  }
 
   /**
    * Hard delete all PAR Data Entities.
@@ -64,5 +71,41 @@ class ParDataStorage extends TranceStorage {
     }
 
     return parent::create($values);
+  }
+
+  /**
+   * Save entity.
+   * This function deletes relationship cache for the new/updated entity refs.
+   *
+   * {@inheritdoc}
+   */
+  public function save(EntityInterface $entity) {
+    // Load the original entity if it already exists.
+    if ($this->has($entity->id(), $entity) && !isset($entity->original)) {
+      $entity->original = $this->loadUnchanged($entity->id());
+    }
+
+    // Get relationships for the entity being saved.
+    $relationships = $entity->getRelationships();
+
+    // Loop through relationships and delete appropriate cache records.
+    foreach ($relationships as $entity_type => $referenced_entities) {
+      foreach ($referenced_entities as $referenced_entity_id => $referenced_entity) {
+        // Skip existing references - they will already be in the cache.
+        if (!empty($entity->original) &&
+            !empty($entity->original->getRelationships()[$referenced_entity_id][$referenced_entity->id()])) {
+          continue;
+        }
+
+        // Delete cache record for new/updated references.
+        \Drupal::cache('data')
+          ->delete("par_data_relationships:{$entity_type}:{$referenced_entity->id()}");
+      }
+    }
+
+    // Warm caches.
+    $this->par_data_manager->getRelatedEntities($entity);
+
+    return parent::save($entity);
   }
 }


### PR DESCRIPTION
The intention of this PR is to fix the bug where _New partnerships aren't added to membership lookup cache_.

