### PR TITLE
implementation of an access callback for Helpdesk Approve Partnership.

### DIFF
--- a/sync/views.view.helpdesk_dashboard.yml
+++ b/sync/views.view.helpdesk_dashboard.yml
@@ -1106,7 +1106,7 @@ display:
           alter:
             alter_text: false
             text: ''
-            make_link: true
+            make_link: false
             path: '/helpdesk/partnership/{{ id }}/confirm'
             absolute: false
             external: false
@@ -1138,13 +1138,13 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: N/A
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
           title: 'Approve partnership'
-          link: ''
-          hidden: 0
+          link: '/helpdesk/partnership/{{ id }}/confirm'
+          hidden: 1
           entity_type: par_data_authority
           plugin_id: par_flow_link
     cache_metadata:

--- a/web/modules/custom/par_flows/src/Form/ParBaseForm.php
+++ b/web/modules/custom/par_flows/src/Form/ParBaseForm.php
@@ -22,6 +22,7 @@ use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\EntityConstraintViolationListInterface;
 use Drupal\par_flows\ParRedirectTrait;
 use Drupal\par_flows\ParDisplayTrait;
+use Drupal\Core\Access\AccessResult;
 
 /**
  * The base form controller for all PAR forms.
@@ -33,6 +34,13 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
   use ParDisplayTrait;
   use StringTranslationTrait;
   use ParControllerTrait;
+
+  /**
+   * The access result
+   *
+   * @var \Drupal\Core\Access\AccessResult
+   */
+  protected $accessResult;
 
   /**
    * The Drupal session manager.
@@ -253,6 +261,20 @@ abstract class ParBaseForm extends FormBase implements ParBaseInterface {
     if (isset($values)) {
       $this->ignoreValues = $values;
     }
+  }
+
+  /**
+   * Access callback
+   * Useful for custom business logic for access.
+   *
+   * @see \Drupal\Core\Access\AccessResult
+   *   The options for callback.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result.
+   */
+  public function accessCallback() {
+    return $this->accessResult ? $this->accessResult : AccessResult::allowed();
   }
 
   /**

--- a/web/modules/features/par_rd_help_desk_flows/par_rd_help_desk_flows.routing.yml
+++ b/web/modules/features/par_rd_help_desk_flows/par_rd_help_desk_flows.routing.yml
@@ -6,6 +6,7 @@ par_help_desks_flows.confirm_partnership:
     _title: 'Please confirm'
   requirements:
     _permission: 'approve partnerships via rd help desk'
+    _custom_access: '\Drupal\par_rd_help_desk_flows\Form\ParRdHelpDeskApproveConfirmForm::accessCallback'
     par_data_partnership: \d+
   options:
     parameters:
@@ -23,7 +24,6 @@ par_help_desks_flows.approve_partnership:
     parameters:
       par_data_partnership:
         type: entity:par_data_partnership
-
 # PAR RD Help Desk journey - invite users
 par_help_desks_flows.invite_members:
   path: '/helpdesk/partnership/{par_data_partnership}/invite/{par_data_person}'

--- a/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveConfirmForm.php
+++ b/web/modules/features/par_rd_help_desk_flows/src/Form/ParRdHelpDeskApproveConfirmForm.php
@@ -5,6 +5,7 @@ namespace Drupal\par_rd_help_desk_flows\Form;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\par_flows\Form\ParBaseForm;
 use Drupal\par_data\Entity\ParDataPartnership;
+use Drupal\Core\Access\AccessResult;
 
 /**
  * The confirming the user is authorised to approve partnerships.
@@ -21,6 +22,18 @@ class ParRdHelpDeskApproveConfirmForm extends ParBaseForm {
    */
   public function getFormId() {
     return 'par_rd_help_desk_confirm';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function accessCallback(ParDataPartnership $par_data_partnership = NULL) {
+    // 403 if the partnership is active/approved by RD.
+    if ($par_data_partnership->getRawStatus() === 'confirmed_rd') {
+      $this->accessResult = AccessResult::forbidden('The partnership is active.');
+    }
+
+    return parent::accessCallback();
   }
 
   /**
@@ -50,20 +63,20 @@ class ParRdHelpDeskApproveConfirmForm extends ParBaseForm {
 
     $form['partnership_title'] = [
       '#type' => 'markup',
-      '#markup' => $this->t('Partnership between between'),
+      '#markup' => $this->t('Partnership between'),
       '#prefix' => '<div><h2>',
       '#suffix' => '</h2></div>',
     ];
 
     $form['partnership_text'] = [
       '#type' => 'markup',
-      '#markup' => $par_data_organisation->get('organisation_name')->getString() . ' ' . $par_data_authority->get('authority_name')->getString(),
+      '#markup' => $par_data_organisation->get('organisation_name')->getString() . ' and ' . $par_data_authority->get('authority_name')->getString(),
       '#default_value' => $this->getDefaultValues('partnership_text'),
       '#prefix' => '<div><p>',
       '#suffix' => '</p></div>',
     ];
 
-    $confirm_text_options[]  = $this->t('I am authorised to approve this partnership');
+    $confirm_text_options[] = $this->t('I am authorised to approve this partnership');
 
     $form['confirm_authorisation_select'] = [
       '#type' => 'radios',


### PR DESCRIPTION
update the view so that it works properly with the PAR Flow Link
implement an access callback in ParBaseForm for use in other areas of the site
add the rule and access callback to approve partnership route

_Active partnerships show N/A_
<img width="873" alt="messages image 2779341995" src="https://user-images.githubusercontent.com/150512/31574271-ea539880-b0c3-11e7-9815-40395f8d4449.png">

_Applications show approve link_

<img width="842" alt="messages image 1517329167" src="https://user-images.githubusercontent.com/150512/31574273-f0bb5550-b0c3-11e7-88ef-844e61c2d099.png">