### PR TITLE
PAR-421 additional features for enforcement notifications

### DIFF
--- a/sync/par_data.par_data_enforcement_action_type.enforcement_action.yml
+++ b/sync/par_data.par_data_enforcement_action_type.enforcement_action.yml
@@ -36,4 +36,3 @@ configuration:
       allowed: Approved
       blocked: Blocked
       referred: Referred
-      approved: Approved

--- a/sync/par_data.par_data_enforcement_action_type.enforcement_action.yml
+++ b/sync/par_data.par_data_enforcement_action_type.enforcement_action.yml
@@ -17,7 +17,7 @@ configuration:
       - title
     status_field: primary_authority_status
     status_transitions:
-      allowed:
+      approved:
         - awaiting_approval
       blocked:
         - awaiting_approval
@@ -33,6 +33,6 @@ configuration:
   primary_authority_status:
     allowed_values:
       awaiting_approval: 'Awaiting approval'
-      allowed: Approved
+      approved: Approved
       blocked: Blocked
       referred: Referred

--- a/sync/par_flows.par_flow.approve_enforcement.yml
+++ b/sync/par_flows.par_flow.approve_enforcement.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: 8HEB1I2IeHAf56MVasNQE4-6Yxnx8SatF36iBzYFdjs
+  default_config_hash: ebM5jbXdBplqjXiuG9y4VQDKE0B6yShqBuEe4y0LOCs
 id: approve_enforcement
 label: 'Approve Enforcement'
 default_title: null
@@ -27,3 +27,7 @@ steps:
       cancel: 4
   4:
     route: view.par_user_enforcements.enforcement_notices_page
+  5:
+    route: par_enforcement_flows.completed_enforcement
+    redirect:
+      done: 4

--- a/sync/par_flows.par_flow.send_enforcement.yml
+++ b/sync/par_flows.par_flow.send_enforcement.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: FvJIXxuKl22aRBxL400EfkgRjw-EIk-KIEoegvmKW1M
+  default_config_hash: Y0uOwoGFUvq3k-KLidK-FHckxL3SIT2NseFp8Zrk-NE
 id: send_enforcement
 label: 'Send Enforcement'
 default_title: null

--- a/sync/views.view.par_user_enforcements.yml
+++ b/sync/views.view.par_user_enforcements.yml
@@ -79,25 +79,65 @@ display:
           summary: ''
           description: ''
           columns:
-            name: name
-            notice_type: notice_type
-            field_partnership: field_partnership
+            id: id
+            title: title
+            par_flow_link: par_flow_link
+            par_flow_link_1: par_flow_link
+            notice_date: notice_date
+            field_enforcing_authority: field_enforcing_authority
+            par_status: par_status
+            field_organisation: field_organisation
           info:
-            name:
+            id:
               sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
-            notice_type:
+            title:
               sortable: false
               default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false
               responsive: ''
-            field_partnership:
+            par_flow_link:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            par_flow_link_1:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            notice_date:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_enforcing_authority:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            par_status:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_organisation:
               sortable: false
               default_sort_order: asc
               align: ''
@@ -718,6 +758,488 @@ display:
     display_options:
       display_extenders: {  }
       path: enforcement-notices
+      fields:
+        id:
+          id: id
+          table: par_enforcement_notices_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ID
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: par_data_enforcement_notice
+          entity_field: id
+          plugin_id: field
+        title:
+          id: title
+          table: par_enforcement_actions_field_data
+          field: title
+          relationship: field_enforcement_action
+          group_type: group
+          admin_label: ''
+          label: Action
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: par_data_enforcement_action
+          entity_field: title
+          plugin_id: field
+        par_flow_link:
+          id: par_flow_link
+          table: par_enforcement_notices_field_data
+          field: par_flow_link
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Title of Action'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          title: '{{ title }}'
+          link: '/enforcement-notice/{{ id }}/approve'
+          hidden: 0
+          entity_type: par_data_enforcement_notice
+          plugin_id: par_flow_link
+        par_flow_link_1:
+          id: par_flow_link_1
+          table: par_enforcement_actions_field_data
+          field: par_flow_link
+          relationship: field_enforcement_action
+          group_type: group
+          admin_label: ''
+          label: 'Title of Action'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          title: '{{ title }}'
+          link: '/enforcement-notice/{{ id }}/reviewed'
+          hidden: 1
+          entity_type: par_data_enforcement_action
+          plugin_id: par_flow_link
+        notice_date:
+          id: notice_date
+          table: par_enforcement_notices_field_data
+          field: notice_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Received Date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_default
+          settings:
+            timezone_override: ''
+            format_type: gds_date_format
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: par_data_enforcement_notice
+          entity_field: notice_date
+          plugin_id: field
+        field_enforcing_authority:
+          id: field_enforcing_authority
+          table: par_data_enforcement_notice__field_enforcing_authority
+          field: field_enforcing_authority
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Enforcing Authority'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        par_status:
+          id: par_status
+          table: par_enforcement_actions_field_data
+          field: par_status
+          relationship: field_enforcement_action
+          group_type: group
+          admin_label: ''
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          entity_type: par_data_enforcement_action
+          plugin_id: par_data_status
+        field_organisation:
+          id: field_organisation
+          table: par_data_partnership__field_organisation
+          field: field_organisation
+          relationship: field_partnership
+          group_type: group
+          admin_label: ''
+          label: Organisation
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      defaults:
+        fields: false
     cache_metadata:
       max-age: 0
       contexts:

--- a/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
@@ -64,7 +64,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  */
 class ParDataEnforcementAction extends ParDataEntity {
 
-  const APPROVED = 'allowed';
+  const APPROVED = 'approved';
   const BLOCKED = 'blocked';
   const REFERRED = 'referred';
   const AWAITING = 'awaiting_approval';

--- a/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
@@ -67,6 +67,7 @@ class ParDataEnforcementAction extends ParDataEntity {
   const APPROVED = 'approved';
   const BLOCKED = 'blocked';
   const REFERRED = 'referred';
+  const AWAITING = 'awaiting_approval';
 
   /**
    * Get the blocked advice for this Enforcement Action.
@@ -182,6 +183,28 @@ class ParDataEnforcementAction extends ParDataEntity {
       return ($this->save() === SAVED_UPDATED);
     }
     return FALSE;
+  }
+
+  /**
+ *  Get the referred note data from the current action.
+ *
+ * @return String referred_text | NULL
+ *   The referred text stored on the current action or null.
+ *
+ */
+  public function getReferralNotes() {
+    return $this->get('referral_notes')->getString();
+  }
+
+  /**
+   *  Get the primary authority notes data from the current action.
+   *
+   * @return String primary_authority_notes | NULL
+   *   The referred text stored on the current action or null.
+   *
+   */
+  public function getPrimaryAuthorityNotes() {
+    return $this->get('primary_authority_notes')->getString();
   }
 
   /**

--- a/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEnforcementAction.php
@@ -64,7 +64,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  */
 class ParDataEnforcementAction extends ParDataEntity {
 
-  const APPROVED = 'approved';
+  const APPROVED = 'allowed';
   const BLOCKED = 'blocked';
   const REFERRED = 'referred';
   const AWAITING = 'awaiting_approval';

--- a/web/modules/custom/par_data/src/Entity/ParDataEnforcementNotice.php
+++ b/web/modules/custom/par_data/src/Entity/ParDataEnforcementNotice.php
@@ -72,6 +72,13 @@ class ParDataEnforcementNotice extends ParDataEntity {
   }
 
   /**
+   * Get the Partnership for this Enforcement Notice.
+   */
+  public function getPartnership() {
+    return $this->get('field_partnership')->referencedEntities();
+  }
+
+  /**
    * Get the enforcing authority for this Enforcement Notice.
    */
   public function getEnforcingAuthority() {

--- a/web/modules/custom/par_flows/src/Controller/ParBaseController.php
+++ b/web/modules/custom/par_flows/src/Controller/ParBaseController.php
@@ -14,6 +14,7 @@ use Drupal\par_flows\ParFlowException;
 use Drupal\par_flows\ParRedirectTrait;
 use Drupal\par_flows\ParDisplayTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Access\AccessResult;
 
 /**
 * A controller for all styleguide page output.
@@ -25,6 +26,13 @@ class ParBaseController extends ControllerBase implements ParBaseInterface {
   use ParDisplayTrait;
   use StringTranslationTrait;
   use ParControllerTrait;
+
+  /**
+   * The access result
+   *
+   * @var \Drupal\Core\Access\AccessResult
+   */
+  protected $accessResult;
 
   /**
    * The flow entity storage class, for loading flows.
@@ -172,6 +180,20 @@ class ParBaseController extends ControllerBase implements ParBaseInterface {
    */
   public function getFlowStorage() {
     return $this->flowStorage;
+  }
+
+  /**
+   * Access callback
+   * Useful for custom business logic for access.
+   *
+   * @see \Drupal\Core\Access\AccessResult
+   *   The options for callback.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result.
+   */
+  public function accessCallback() {
+    return $this->accessResult ? $this->accessResult : AccessResult::allowed();
   }
 
 }

--- a/web/modules/features/par_data_config/config/install/par_data.par_data_enforcement_action_type.enforcement_action.yml
+++ b/web/modules/features/par_data_config/config/install/par_data.par_data_enforcement_action_type.enforcement_action.yml
@@ -33,4 +33,3 @@ configuration:
       allowed: Approved
       blocked: Blocked
       referred: Referred
-      approved: Approved

--- a/web/modules/features/par_data_config/config/install/par_data.par_data_enforcement_action_type.enforcement_action.yml
+++ b/web/modules/features/par_data_config/config/install/par_data.par_data_enforcement_action_type.enforcement_action.yml
@@ -30,6 +30,6 @@ configuration:
   primary_authority_status:
     allowed_values:
       awaiting_approval: 'Awaiting approval'
-      allowed: Approved
+      approved: Approved
       blocked: Blocked
       referred: Referred

--- a/web/modules/features/par_data_config/config/install/par_data.par_data_enforcement_action_type.enforcement_action.yml
+++ b/web/modules/features/par_data_config/config/install/par_data.par_data_enforcement_action_type.enforcement_action.yml
@@ -14,7 +14,7 @@ configuration:
       - title
     status_field: primary_authority_status
     status_transitions:
-      allowed:
+      approved:
         - awaiting_approval
       blocked:
         - awaiting_approval

--- a/web/modules/features/par_data_config/par_data_config.info.yml
+++ b/web/modules/features/par_data_config/par_data_config.info.yml
@@ -6,6 +6,7 @@ package: PAR
 dependencies:
   - address
   - better_exposed_filters
+  - csv_serialization
   - datetime
   - datetime_range
   - field
@@ -13,6 +14,10 @@ dependencies:
   - file_entity
   - pagerer
   - par_data
+  - rest
+  - serialization
   - text
   - user
   - views
+  - views_bulk_operations
+  - views_data_export

--- a/web/modules/features/par_enforcement_flows/config/install/par_flows.par_flow.approve_enforcement.yml
+++ b/web/modules/features/par_enforcement_flows/config/install/par_flows.par_flow.approve_enforcement.yml
@@ -24,3 +24,7 @@ steps:
       cancel: 4
   4:
     route: view.par_user_enforcements.enforcement_notices_page
+  5:
+    route: par_enforcement_flows.completed_enforcement
+    redirect:
+      done: 4

--- a/web/modules/features/par_enforcement_flows/par_enforcement_flows.routing.yml
+++ b/web/modules/features/par_enforcement_flows/par_enforcement_flows.routing.yml
@@ -123,6 +123,7 @@ par_enforcement_flows.approve:
     _title: 'Approve Enforcement Notice'
   requirements:
     _permission: 'approve enforcement notice'
+    _custom_access: '\Drupal\par_enforcement_flows\Form\ParEnforcementApproveNoticeForm::accessCallback'
     par_data_enforcement_notice: \d+
   options:
     parameters:
@@ -147,12 +148,12 @@ par_enforcement_flows.approve_confirm:
     _title: 'Confirm Enforcement Notice'
   requirements:
     _permission: 'approve enforcement notice'
+    _custom_access: '\Drupal\par_enforcement_flows\Form\ParEnforcementConfirmNoticeForm::accessCallback'
     par_data_enforcement_notice: \d+
   options:
     parameters:
       par_data_enforcement_notice:
         type: entity:par_data_enforcement_notice
-
 # PAR Data Send Enforcement Notice To Organisation
 par_enforcement_flows.send:
   path: '/enforcement-notice/{par_data_enforcement_notice}/send'
@@ -162,6 +163,20 @@ par_enforcement_flows.send:
   requirements:
     _permission: 'send enforcement notice'
     par_data_enforcement_notice: \d+
+  options:
+    parameters:
+      par_data_enforcement_notice:
+        type: entity:par_data_enforcement_notice
+# Review a raised enforcement notice that has been acted on.
+par_enforcement_flows.completed_enforcement:
+  path: '/enforcement-notice/{par_data_enforcement_notice}/reviewed'
+  defaults:
+    _controller: '\Drupal\par_enforcement_flows\Controller\ParEnforcementFlowsCompletedEnforcementController::content'
+    _title_callback: '\Drupal\par_enforcement_flows\Controller\ParEnforcementFlowsCompletedEnforcementController::titleCallback'
+  requirements:
+    _permission: 'raise enforcement notice'
+    _custom_access: '\Drupal\par_enforcement_flows\Controller\ParEnforcementFlowsCompletedEnforcementController::accessCallback'
+    par_data_partnership: \d+
   options:
     parameters:
       par_data_enforcement_notice:

--- a/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
+++ b/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
@@ -115,7 +115,18 @@ class ParEnforcementFlowsCompletedEnforcementController extends ParBaseControlle
     ];
     // Display all enforcement actions assigned to this enforcement action.
     foreach ($enforcement_actions as $enforcement_action) {
-      $build[$enforcement_action->id()]['action_title'] = $this->renderSection('Proposed enforcement action', $enforcement_action, ['title' => 'title'], [], TRUE, TRUE);
+      $action_state = $enforcement_action->get('primary_authority_status')->getString();
+
+      if ($action_state === ParDataEnforcementAction::REFERRED) {
+        $reason =  $this->renderSection('Reason', $enforcement_action, ['referral_notes' => 'summary'], [], TRUE, TRUE);
+      }
+      if ($action_state === ParDataEnforcementAction::BLOCKED) {
+        $reason =  $this->renderSection('Reason', $enforcement_action, ['primary_authority_notes' => 'summary'], [], TRUE, TRUE);
+      }
+
+      $build[$enforcement_action->id()]['action_title'] = $this->renderSection('Title of action', $enforcement_action, ['title' => 'title'], [], TRUE, TRUE);
+      $build[$enforcement_action->id()]['decision'] = $this->renderSection('Decision', $enforcement_action, ['primary_authority_status' => 'summary'], [], TRUE, TRUE);
+      $build[$enforcement_action->id()]['reason'] = $reason ? $reason : NULL;
       $build[$enforcement_action->id()]['action_regulatory_function'] = $this->renderSection('Regulatory function', $enforcement_action, ['field_regulatory_function' => 'summary'], [], TRUE, TRUE);
       $build[$enforcement_action->id()]['action_details'] = $this->renderSection('Details', $enforcement_action, ['details' => 'summary'], [], TRUE, TRUE);
       $build[$enforcement_action->id()]['action_attach_title'] = $doc_title;

--- a/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
+++ b/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
@@ -107,11 +107,18 @@ class ParEnforcementFlowsCompletedEnforcementController extends ParBaseControlle
     $build['registered_address']['address'] = $this->renderSection('Registered address', $par_data_organisation, ['field_premises' => 'summary'], [], FALSE, TRUE);
     $build['enforcement_summary'] = $this->renderSection('Summary of enforcement notice', $par_data_enforcement_notice, ['summary' => 'summary'], [], TRUE, TRUE);
 
+    $doc_title =[
+      '#type' => 'markup',
+      '#markup' => $this->t('Attached files'),
+      '#prefix' => '<h3>',
+      '#suffix' => '</h3>',
+    ];
     // Display all enforcement actions assigned to this enforcement action.
     foreach ($enforcement_actions as $enforcement_action) {
       $build[$enforcement_action->id()]['action_title'] = $this->renderSection('Proposed enforcement action', $enforcement_action, ['title' => 'title'], [], TRUE, TRUE);
       $build[$enforcement_action->id()]['action_regulatory_function'] = $this->renderSection('Regulatory function', $enforcement_action, ['field_regulatory_function' => 'summary'], [], TRUE, TRUE);
       $build[$enforcement_action->id()]['action_details'] = $this->renderSection('Details', $enforcement_action, ['details' => 'summary'], [], TRUE, TRUE);
+      $build[$enforcement_action->id()]['action_attach_title'] = $doc_title;
       $build[$enforcement_action->id()]['action_attach'] = $this->renderMarkupField($enforcement_action->get('document')->view('full'));
     }
     return parent::build($build);

--- a/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
+++ b/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
@@ -22,10 +22,6 @@ class ParEnforcementFlowsCompletedEnforcementController extends ParBaseControlle
    */
   public function accessCallback(ParDataEnforcementNotice $par_data_enforcement_notice = NULL) {
 
-    // current user should be the enforcement officer or the primary authority user.
-    // the enforcement notice state should be acted on
-    // none of the attached actions should be in awaiting approve state.
-
     $allowed_actions = [
       ParDataEnforcementAction::APPROVED,
       ParDataEnforcementAction::BLOCKED,
@@ -54,8 +50,6 @@ class ParEnforcementFlowsCompletedEnforcementController extends ParBaseControlle
    */
   public function content(ParDataEnforcementNotice $par_data_enforcement_notice = NULL) {
 
-
-
     // Organisation summary.
     $partnership = current($par_data_enforcement_notice->getPartnership());
     $par_data_organisation = current($partnership->getOrganisation());
@@ -63,7 +57,6 @@ class ParEnforcementFlowsCompletedEnforcementController extends ParBaseControlle
 
     // Load all enforcement actions for the current enforcement notification.
     $enforcement_actions = $par_data_enforcement_notice->getEnforcementAction();
-
 
     $build['authority'] =[
       '#type' => 'fieldset',
@@ -90,7 +83,6 @@ class ParEnforcementFlowsCompletedEnforcementController extends ParBaseControlle
       '#collapsible' => FALSE,
       '#collapsed' => FALSE,
     ];
-
 
     $build['organisation']['organisation_heading'] = [
       '#type' => 'markup',

--- a/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
+++ b/web/modules/features/par_enforcement_flows/src/Controller/ParEnforcementFlowsCompletedEnforcementController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\par_enforcement_flows\Controller;
+
+use Drupal\par_data\Entity\ParDataEnforcementAction;
+use Drupal\par_data\Entity\ParDataEnforcementNotice;
+use Drupal\par_flows\Controller\ParBaseController;
+use Drupal\Core\Access\AccessResult;
+
+/**
+ * A controller for rendering a specific partner page.
+ */
+class ParEnforcementFlowsCompletedEnforcementController extends ParBaseController {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $flow = 'approve_enforcement';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function accessCallback(ParDataEnforcementNotice $par_data_enforcement_notice = NULL) {
+
+    // current user should be the enforcement officer or the primary authority user.
+    // the enforcement notice state should be acted on
+    // none of the attached actions should be in awaiting approve state.
+
+    $allowed_actions = [
+      ParDataEnforcementAction::APPROVED,
+      ParDataEnforcementAction::BLOCKED,
+      ParDataEnforcementAction::REFERRED,
+      ParDataEnforcementAction::AWAITING,
+    ];
+
+    foreach ($par_data_enforcement_notice->get('field_enforcement_action')->referencedEntities() as $delta => $action) {
+      // If this enforcement notice has any actions that have not yet been reviewed deny access.
+      if (in_array($action->getRawStatus(), $allowed_actions) && $action->getRawStatus() === ParDataEnforcementAction::AWAITING) {
+        $this->accessResult = AccessResult::forbidden('This enforcement notification has not been fully reviewed yet.');
+      }
+    }
+    return parent::accessCallback();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function titleCallback() {
+    return;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function content(ParDataEnforcementNotice $par_data_enforcement_notice = NULL) {
+
+
+
+    // Organisation summary.
+    $partnership = current($par_data_enforcement_notice->getPartnership());
+    $par_data_organisation = current($partnership->getOrganisation());
+    $par_data_authority = current($partnership->getAuthority());
+
+    // Load all enforcement actions for the current enforcement notification.
+    $enforcement_actions = $par_data_enforcement_notice->getEnforcementAction();
+
+
+    $build['authority'] =[
+      '#type' => 'fieldset',
+      '#attributes' => ['class' => 'form-group'],
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+    $build['authority']['authority_heading'] = [
+      '#type' => 'markup',
+      '#markup' => $this->t('Response to notification of enforcement action received from'),
+    ];
+
+    $build['authority']['authority_name'] = [
+      '#type' => 'markup',
+      '#markup' => $par_data_authority->get('authority_name')->getString(),
+      '#prefix' => '<div><h2>',
+      '#suffix' => '</h2></div>',
+    ];
+
+    $build['organisation'] =[
+      '#type' => 'fieldset',
+      '#attributes' => ['class' => 'form-group'],
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+    ];
+
+
+    $build['organisation']['organisation_heading'] = [
+      '#type' => 'markup',
+      '#markup' => $this->t('In partnership with'),
+      '#prefix' => '<h2>',
+      '#suffix' => '</h2>',
+    ];
+
+    $build['organisation']['organisation_name'] = [
+      '#type' => 'markup',
+      '#markup' => $par_data_organisation->get('organisation_name')->getString(),
+    ];
+
+    $build['registered_address']['registered_address_heading'] = [
+      '#type' => 'markup',
+      '#markup' => $this->t('Business address'),
+      '#prefix' => '<h2>',
+      '#suffix' => '</h2>',
+    ];
+
+    // Display the primary address.
+    $build['registered_address']['address'] = $this->renderSection('Registered address', $par_data_organisation, ['field_premises' => 'summary'], [], FALSE, TRUE);
+    $build['enforcement_summary'] = $this->renderSection('Summary of enforcement notice', $par_data_enforcement_notice, ['summary' => 'summary'], [], TRUE, TRUE);
+
+    // Display all enforcement actions assigned to this enforcement action.
+    foreach ($enforcement_actions as $enforcement_action) {
+      $build[$enforcement_action->id()]['action_title'] = $this->renderSection('Proposed enforcement action', $enforcement_action, ['title' => 'title'], [], TRUE, TRUE);
+      $build[$enforcement_action->id()]['action_regulatory_function'] = $this->renderSection('Regulatory function', $enforcement_action, ['field_regulatory_function' => 'summary'], [], TRUE, TRUE);
+      $build[$enforcement_action->id()]['action_details'] = $this->renderSection('Details', $enforcement_action, ['details' => 'summary'], [], TRUE, TRUE);
+      $build[$enforcement_action->id()]['action_attach'] = $this->renderMarkupField($enforcement_action->get('document')->view('full'));
+    }
+    return parent::build($build);
+  }
+}

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementAddActionForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementAddActionForm.php
@@ -110,7 +110,7 @@ class ParEnforcementAddActionForm extends ParBaseForm {
     if ($enforcementAction->save()) {
 
       $enforcement_notice = $this->getRouteParam('par_data_enforcement_notice');
-      //Store the created action on the current enforcement entity.
+      // Store the created action on the current enforcement entity.
       $enforcement_action_ids = $enforcementAction->id();
 
       $enforcement_notice->field_enforcement_action[] = $enforcement_action_ids;

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementApproveNoticeForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementApproveNoticeForm.php
@@ -26,6 +26,15 @@ class ParEnforcementApproveNoticeForm extends ParBaseForm {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function accessCallback(ParDataEnforcementNotice $par_data_enforcement_notice = NULL) {
+
+    // Additional business logic can implement here to 403.
+    return parent::accessCallback();
+  }
+
+  /**
    * Helper to get all the editable values when editing or
    * revisiting a previously edited page.
    */
@@ -41,6 +50,9 @@ class ParEnforcementApproveNoticeForm extends ParBaseForm {
       foreach ($par_data_enforcement_notice->get('field_enforcement_action')->referencedEntities() as $delta => $action) {
         if (in_array($action->getRawStatus(), $allowed_actions)) {
           $this->loadDataValue(['actions', $delta, 'disabled'], TRUE);
+          $this->loadDataValue(['actions', $delta, 'primary_authority_status'], $action->getRawStatus());
+          $this->loadDataValue(['actions', $delta, 'referral_notes'], $action->getReferralNotes());
+          $this->loadDataValue(['actions', $delta, 'primary_authority_notes'], $action->getPrimaryAuthorityNotes());
         }
       }
     }
@@ -76,6 +88,7 @@ class ParEnforcementApproveNoticeForm extends ParBaseForm {
       ];
     }
     foreach ($par_data_enforcement_notice->get('field_enforcement_action')->referencedEntities() as $delta => $action) {
+
       $form['actions'][$delta] = [
         '#type' => 'fieldset',
         '#collapsible' => FALSE,

--- a/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementConfirmNoticeForm.php
+++ b/web/modules/features/par_enforcement_flows/src/Form/ParEnforcementConfirmNoticeForm.php
@@ -9,6 +9,7 @@ use Drupal\par_data\Entity\ParDataEnforcementNotice;
 use Drupal\par_data\Entity\ParDataPartnership;
 use Drupal\par_data\ParDataException;
 use Drupal\par_flows\Form\ParBaseForm;
+use Drupal\Core\Access\AccessResult;
 
 /**
  * The confirmation for creating a new enforcement notice.
@@ -19,6 +20,21 @@ class ParEnforcementConfirmNoticeForm extends ParBaseForm {
    * {@inheritdoc}
    */
   protected $flow = 'approve_enforcement';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function accessCallback(ParDataEnforcementNotice $par_data_enforcement_notice = NULL) {
+
+    // This form should only be accessed if none of the enforcement notice actions have been acted on.
+    foreach ($par_data_enforcement_notice->get('field_enforcement_action')->referencedEntities() as $delta => $action) {
+      // Set an error if this action has already been reviewed.
+      if ($action->isApproved() || $action->isBlocked() || $action->isReferred()) {
+        $this->accessResult = AccessResult::forbidden('This action has already been reviewed.');
+      }
+    }
+    return parent::accessCallback();
+  }
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
This PR adds custom access control to ensure the correct users can/cannot access versions of the notification actions dictated by custom business logic.

Custom flow link added to enforcement notifications view to control the displaying of actions that need to be reviewed or acted on depending on the logged in user role (enforcement officer / primary authority user).

Review controller added to display the resulting acted upon enforcement notification.